### PR TITLE
Fix exception when importing as XML

### DIFF
--- a/gml_application_schema_toolbox/core/load_gml_as_xml.py
+++ b/gml_application_schema_toolbox/core/load_gml_as_xml.py
@@ -34,6 +34,8 @@ from .qgis_urlopener import remote_open_from_qgis
 from .xml_utils import no_prefix, split_tag, resolve_xpath, xml_parse
 from .gml_utils import extract_features
 
+from qgis.utils import spatialite_connect
+
 __all__ = ['load_as_xml_layer', 'properties_from_layer', 'is_layer_gml_xml']
 
 def load_as_xml_layer(xml_uri, is_remote, attributes = {}, geometry_mapping = None, output_local_file = None, logger = None, swap_xy = False):


### PR DESCRIPTION
Fixes

traceback:  File "/home/even/.qgis3/python/plugins/gml_application_schema_toolbox/gui/import_xml_panel.py", line 78, in on_importButton_clicked
    swap_xy = self.swapXYCheck.isChecked())
  File "/home/even/.qgis3/python/plugins/gml_application_schema_toolbox/core/load_gml_as_xml.py", line 56, in load_as_xml_layer
    return s.load_complex_gml(xml_uri, is_remote, attributes, geometry_mapping, logger, swap_xy)

Warning 1: The '' extension is not allowed by the GPKG specification, which may cause compatibility problems
src/core/qgsmessagelog.cpp: 33: (logMessage) [32ms] 2017-07-07T18:07:15 Erreur Python[1] Traceback (most recent call last):
  File "/home/even/.qgis3/python/plugins/gml_application_schema_toolbox/gui/import_xml_panel.py", line 78, in on_importButton_clicked
    swap_xy = self.swapXYCheck.isChecked())
  File "/home/even/.qgis3/python/plugins/gml_application_schema_toolbox/core/load_gml_as_xml.py", line 56, in load_as_xml_layer
    return s.load_complex_gml(xml_uri, is_remote, attributes, geometry_mapping, logger, swap_xy)
  File "/home/even/.qgis3/python/plugins/gml_application_schema_toolbox/core/load_gml_as_xml.py", line 254, in load_complex_gml
    layer = self._create_layer('point', srid, attr_list, src.title + " (points)")
  File "/home/even/.qgis3/python/plugins/gml_application_schema_toolbox/core/load_gml_as_xml.py", line 360, in _create_layer
    conn = spatialite_connect(self.output_local_file)
NameError: name 'spatialite_connect' is not defined