### PR TITLE
Catch Exception for missing StoredQueries

### DIFF
--- a/gml_application_schema_toolbox/gui/load_wizard_wfs.py
+++ b/gml_application_schema_toolbox/gui/load_wizard_wfs.py
@@ -187,14 +187,29 @@ class LoadWizardWFS(QWizardPage, PAGE_1A_W):
         self.featureTypesTableWidget.sortItems(1)
 
         self.storedQueriesListWidget.clear()
-        if hasattr(wfs, "storedqueries"):
-            for stored_query in list(wfs.storedqueries):
-                params = ", ".join(
-                    ["{}: {}".format(p.name, p.type) for p in stored_query.parameters]
+        try:
+            if hasattr(wfs, "storedqueries"):
+                for stored_query in list(wfs.storedqueries):
+                    params = ", ".join(
+                        [
+                            "{}: {}".format(p.name, p.type)
+                            for p in stored_query.parameters
+                        ]
+                    )
+                    self.storedQueriesListWidget.addItem(
+                        "{}({})".format(stored_query.id, params)
+                    )
+                self.datasetsTabWidget.setTabEnabled(
+                    self.datasetsTabWidget.indexOf(self.tab_2), True
                 )
-                self.storedQueriesListWidget.addItem(
-                    "{}({})".format(stored_query.id, params)
+            else:
+                self.datasetsTabWidget.setTabEnabled(
+                    self.datasetsTabWidget.indexOf(self.tab_2), False
                 )
+        except ServiceException:
+            self.datasetsTabWidget.setTabEnabled(
+                self.datasetsTabWidget.indexOf(self.tab_2), False
+            )
 
         self.storedQueriesListWidget.sortItems()
 


### PR DESCRIPTION
This PR addresses #229. 
I added a try block to catch the ows ServiceExceptions that gets thrown, when a WFS does not support the `ListStoredQueries` method. 
To inform the user about the missing StoredQueries, the corresponding tab gets disabled in the UI.

